### PR TITLE
Add AllowedMentions

### DIFF
--- a/src/main/java/io/github/_4drian3d/jdwebhooks/AllowedMentions.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/AllowedMentions.java
@@ -31,6 +31,14 @@ public record AllowedMentions(
         if (users.size() > MAX_ID_ARRAY) {
             throw new IllegalArgumentException("users cannot contain more than " + MAX_ID_ARRAY + " entries");
         }
+
+        // check for mutual exclusivity: parse is mutually exclusive with roles and users
+        if(parse.contains("users") && !users.isEmpty()) {
+            throw new IllegalArgumentException("Cannot specify 'users' in parse and also provide user ids");
+        }
+        if(parse.contains("roles") && !roles.isEmpty()) {
+            throw new IllegalArgumentException("Cannot specify 'roles' in parse and also provide role ids");
+        }
     }
 
     private static List<String> validateAndNormalizeParse(Collection<String> input) {

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/AllowedMentions.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/AllowedMentions.java
@@ -1,0 +1,160 @@
+package io.github._4drian3d.jdwebhooks;
+
+import org.jetbrains.annotations.*;
+
+import java.util.*;
+
+/**
+ * Immutable wrapper for Discord's Allowed Mentions object.
+ */
+public record AllowedMentions(
+        @Nullable List<String> parse,
+        @Nullable List<String> roles,
+        @Nullable List<String> users,
+        @Nullable Boolean repliedUser
+) {
+
+    private static final Set<String> ALLOWED_PARSE = Set.of("users", "roles", "everyone");
+    private static final int MAX_ID_ARRAY = 100;
+
+    public AllowedMentions {
+        // normalize / default handling
+        parse = (parse == null) ? List.of() : List.copyOf(validateAndNormalizeParse(parse));
+        roles = (roles == null) ? List.of() : List.copyOf(roles);
+        users = (users == null) ? List.of() : List.copyOf(users);
+        repliedUser = (repliedUser == null) ? Boolean.FALSE : repliedUser;
+
+        // enforce Discord limits
+        if (roles.size() > MAX_ID_ARRAY) {
+            throw new IllegalArgumentException("roles cannot contain more than " + MAX_ID_ARRAY + " entries");
+        }
+        if (users.size() > MAX_ID_ARRAY) {
+            throw new IllegalArgumentException("users cannot contain more than " + MAX_ID_ARRAY + " entries");
+        }
+    }
+
+    private static List<String> validateAndNormalizeParse(Collection<String> input) {
+        List<String> normalized = new ArrayList<>(input.size());
+        for (String raw : input) {
+            if (raw == null) continue;
+            String token = raw.trim().toLowerCase(Locale.ROOT);
+            if (!ALLOWED_PARSE.contains(token)) {
+                throw new IllegalArgumentException("Invalid parse token: " + raw + ". Allowed: " + ALLOWED_PARSE);
+            }
+            if (!normalized.contains(token)) { // avoid duplicates
+                normalized.add(token);
+            }
+        }
+        return normalized;
+    }
+
+    /** Convenient empty instance (no mentions, replied_user = false). */
+    public static AllowedMentions empty() {
+        return new AllowedMentions(List.of(), List.of(), List.of(), Boolean.FALSE);
+    }
+
+    /** Gets the default AllowedMentions instance, which parses users, roles and everyone. */
+    public static AllowedMentions getDefault() {
+        return new AllowedMentions(
+                List.of("users", "roles", "everyone"),
+                List.of(),
+                List.of(),
+                Boolean.FALSE
+        );
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Builder for AllowedMentions */
+    @SuppressWarnings({"UnusedReturnValue"})
+    public static final class Builder {
+        private final List<String> parse = new ArrayList<>();
+        private final List<String> roles = new ArrayList<>();
+        private final List<String> users = new ArrayList<>();
+        private Boolean repliedUser = Boolean.FALSE;
+
+        private void addParse(String token) {
+            if (token == null) return;
+            if (!ALLOWED_PARSE.contains(token)) {
+                throw new IllegalArgumentException("Invalid parse token: " + token);
+            }
+            if (!parse.contains(token)) parse.add(token);
+        }
+
+        public Builder parseUser(Boolean parseUser) {
+            if (parseUser == null || !parseUser) {
+                parse.remove("users");
+            } else {
+                addParse("users");
+            }
+            return this;
+        }
+
+        public Builder parseRoles(Boolean parseRoles) {
+            if (parseRoles == null || !parseRoles) {
+                parse.remove("roles");
+            } else {
+                addParse("roles");
+            }
+            return this;
+        }
+
+        public Builder parseEveryone(Boolean parseEveryone) {
+            if (parseEveryone == null || !parseEveryone) {
+                parse.remove("everyone");
+            } else {
+                addParse("everyone");
+            }
+            return this;
+        }
+
+
+        public Builder roles(Collection<String> ids) {
+            if (ids == null) return this;
+            roles.clear();
+            for (String id : ids) addRole(id);
+            return this;
+        }
+
+        public Builder addRole(String id) {
+            if (id == null) return this;
+            if (roles.size() >= MAX_ID_ARRAY) {
+                throw new IllegalStateException("Cannot add more than " + MAX_ID_ARRAY + " role ids");
+            }
+            roles.add(id);
+            return this;
+        }
+
+        public Builder users(Collection<String> ids) {
+            if (ids == null) return this;
+            users.clear();
+            for (String id : ids) addUser(id);
+            return this;
+        }
+
+        public Builder addUser(String id) {
+            if (id == null) return this;
+            if (users.size() >= MAX_ID_ARRAY) {
+                throw new IllegalStateException("Cannot add more than " + MAX_ID_ARRAY + " user ids");
+            }
+            users.add(id);
+            return this;
+        }
+
+        public Builder repliedUser(Boolean replied) {
+            this.repliedUser = (replied == null) ? Boolean.FALSE : replied;
+            return this;
+        }
+
+        public AllowedMentions build() {
+            return new AllowedMentions(
+                    parse.isEmpty() ? List.of() : List.copyOf(parse),
+                    roles.isEmpty() ? List.of() : List.copyOf(roles),
+                    users.isEmpty() ? List.of() : List.copyOf(users),
+                    repliedUser == null ? Boolean.FALSE : repliedUser
+            );
+        }
+    }
+}

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/WebHook.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/WebHook.java
@@ -26,7 +26,7 @@ public record WebHook(
         @Nullable String avatarURL,
         @Nullable Boolean tts,
         @Nullable List<Embed> embeds,
-        @Nullable Boolean allowedMentions,
+        @Nullable AllowedMentions allowedMentions,
         @Nullable String threadName
 ) {
     public WebHook {
@@ -51,7 +51,7 @@ public record WebHook(
         private String avatarURL;
         private Boolean tts;
         private List<Embed> embeds;
-        private Boolean allowedMentions;
+        private AllowedMentions allowedMentions;
         private String threadName;
 
         private Builder() {
@@ -122,7 +122,7 @@ public record WebHook(
             return this;
         }
 
-        public Builder allowedMentions(final @Nullable Boolean allowedMentions) {
+        public Builder allowedMentions(final @Nullable AllowedMentions allowedMentions) {
             this.allowedMentions = allowedMentions;
             return this;
         }

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/WebHookClient.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/WebHookClient.java
@@ -2,9 +2,7 @@ package io.github._4drian3d.jdwebhooks;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import io.github._4drian3d.jdwebhooks.serializer.DateSerializer;
-import io.github._4drian3d.jdwebhooks.serializer.EmbedSerializer;
-import io.github._4drian3d.jdwebhooks.serializer.WebHookSerializer;
+import io.github._4drian3d.jdwebhooks.serializer.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URI;
@@ -32,6 +30,7 @@ public final class WebHookClient {
             .registerTypeAdapter(OffsetDateTime.class, new DateSerializer())
             .registerTypeAdapter(Embed.class, new EmbedSerializer())
             .registerTypeAdapter(WebHook.class, new WebHookSerializer())
+            .registerTypeAdapter(AllowedMentions.class, new AllowedMentionsSerializer())
             .create();
 
     private WebHookClient(final Builder builder) {

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/AllowedMentionsSerializer.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/AllowedMentionsSerializer.java
@@ -1,0 +1,35 @@
+package io.github._4drian3d.jdwebhooks.serializer;
+
+import com.google.gson.*;
+import io.github._4drian3d.jdwebhooks.*;
+
+import java.lang.reflect.*;
+
+public final class AllowedMentionsSerializer implements JsonSerializer<AllowedMentions>, CommonSerializer {
+    @Override
+    public JsonElement serialize(AllowedMentions allowedMentions, Type type, JsonSerializationContext context) {
+        final JsonObject object = new JsonObject();
+
+        final var parse = allowedMentions.parse();
+        if(parse != null && !parse.isEmpty()) {
+            object.add("parse", context.serialize(parse));
+        }
+
+        final var roles = allowedMentions.roles();
+        if (roles != null && !roles.isEmpty()) {
+            object.add("roles", context.serialize(roles));
+        }
+
+        final var users = allowedMentions.users();
+        if (users != null && !users.isEmpty()) {
+            object.add("users", context.serialize(users));
+        }
+
+        final var repliedUser = allowedMentions.repliedUser();
+        if (Boolean.TRUE.equals(repliedUser)) {
+            object.addProperty("replied_user", true);
+        }
+
+        return object;
+    }
+}

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/AllowedMentionsSerializer.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/AllowedMentionsSerializer.java
@@ -11,7 +11,8 @@ public final class AllowedMentionsSerializer implements JsonSerializer<AllowedMe
         final JsonObject object = new JsonObject();
 
         final var parse = allowedMentions.parse();
-        if(parse != null && !parse.isEmpty()) {
+        // we don't check for empty, because an empty parse list has a different meaning than no parse at all
+        if(parse != null) {
             object.add("parse", context.serialize(parse));
         }
 

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/CommonSerializer.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/CommonSerializer.java
@@ -4,7 +4,7 @@ import com.google.gson.JsonObject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-sealed interface CommonSerializer permits EmbedSerializer, WebHookSerializer {
+sealed interface CommonSerializer permits EmbedSerializer, WebHookSerializer, AllowedMentionsSerializer {
     default void addNonNull(
             final @NotNull JsonObject object,
             final @NotNull String name,

--- a/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/WebHookSerializer.java
+++ b/src/main/java/io/github/_4drian3d/jdwebhooks/serializer/WebHookSerializer.java
@@ -20,8 +20,12 @@ public final class WebHookSerializer implements JsonSerializer<WebHook>, CommonS
         this.addNonNull(object, "username", src.username());
         this.addNonNull(object, "avatar_url", src.avatarURL());
         this.addNonNull(object, "tts", src.tts());
-        this.addNonNull(object, "allowed_mentions", src.allowedMentions());
         this.addNonNull(object, "thread_name", src.threadName());
+
+        final var allowedMentions = src.allowedMentions();
+        if (allowedMentions != null) {
+            object.add("allowed_mentions", context.serialize(allowedMentions));
+        }
 
         final var embeds = src.embeds();
         if (embeds != null) {


### PR DESCRIPTION
Fixes #35 

This PR adds the AllowedMentions class to add support to Discord's [allowed mentions object](https://discord.com/developers/docs/resources/message#allowed-mentions-object).

Breaking changes:
- `Webhook.Builder#allowedMentions` now takes in a `final @Nullable AllowedMentions` object.
- `Webook#allowedMentions` now returns a `@Nullable AllowedMentions` object.

Usage (note that Kotlin is used for the examples):
```kotlin
// create a message that won't mention anyone
val webhookMessage =
    WebHook
        .builder()
        .content("No mentions here, @everyone @here <@730775136881475645>")
        .allowedMentions(AllowedMentions.empty())
        .build()

// create a message that will parse @everyone and only <@730775136881475645> but not other users
val webhookMessage =
    WebHook
        .builder()
        .content("Hi @everyone, also <@730775136881475645> but not <@&1340041752140054528> (role mention) or <@630093013074575370>")
        .allowedMentions(
            AllowedMentions
                .builder()
                .parseEveryone(true)
                .addUser("730775136881475645")
                .build(),
        ).build()
```